### PR TITLE
added numpy_loading.py where the dataloader only uses .npy files to remove dataloading bottleneck

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from tqdm import tqdm
 
 from evaluate import evaluate
 from unet import UNet
-from utils.data_loading import BasicDataset
+from utils.numpy_loading import BasicDataset
 from utils.dice_score import dice_loss
 
 dir_img = Path('./data/imgs/')
@@ -43,7 +43,7 @@ def train_net(net,
               val_dir: Path = None,
               workers: int = 4
               ):
-    train_set = BasicDataset(train_path / "images", train_path / "masks", scale=img_scale, mapping=mapping)
+    train_set = BasicDataset(train_path / "images", train_path / "masks", scale=img_scale, mapping=mapping, train=True)
     val_set = BasicDataset(val_dir / "images", val_dir / "masks", scale=img_scale, mapping=mapping)
 
     # 3. Create data loaders

--- a/train.py
+++ b/train.py
@@ -21,7 +21,8 @@ from tqdm import tqdm
 
 from evaluate import evaluate
 from unet import UNet
-from utils.numpy_loading import BasicDataset
+from utils.numpy_loading import NumpyDataset
+from utils.data_loading import BasicDataset
 from utils.dice_score import dice_loss
 
 dir_img = Path('./data/imgs/')
@@ -41,10 +42,16 @@ def train_net(net,
               mapping: Dict[Tuple[int, int, int], int] = None,
               train_path: Path = None,
               val_dir: Path = None,
-              workers: int = 4
+              workers: int = 4,
+              load_np: bool = False
               ):
-    train_set = BasicDataset(train_path / "images", train_path / "masks", scale=img_scale, mapping=mapping, train=True)
-    val_set = BasicDataset(val_dir / "images", val_dir / "masks", scale=img_scale, mapping=mapping)
+
+    if load_np:
+        train_set = NumpyDataset(train_path / "images", train_path / "masks", scale=img_scale, mapping=mapping, train=True)
+        val_set = NumpyDataset(val_dir / "images", val_dir / "masks", scale=img_scale, mapping=mapping)
+    else:
+        train_set = BasicDataset(train_path / "images", train_path / "masks", scale=img_scale, mapping=mapping)
+        val_set = BasicDataset(val_dir / "images", val_dir / "masks", scale=img_scale, mapping=mapping)
 
     # 3. Create data loaders
     loader_args = dict(batch_size=batch_size, num_workers=workers, pin_memory=True)
@@ -68,6 +75,7 @@ def train_net(net,
         Device:          {device.type}
         Images scaling:  {img_scale}
         Mixed Precision: {amp}
+        Load from Numpy: {load_np}
     ''')
 
     # 4. Set up the optimizer, the loss, the learning rate scheduler and the loss scaling for AMP
@@ -165,6 +173,8 @@ def get_args():
     parser.add_argument('--classes', '-c', type=int, default=2, help='Number of classes')
     parser.add_argument('--mapping', '-m', type=str, default="{}", help='JSON of (R,G,B) -> Class. Implies/overides -c')
     parser.add_argument('--data-dir', '-d', type=str, default=None, help="directory to find data in")
+    parser.add_argument('--load-from-npy', '-n', action='store_true', default=False, dest='load_np',
+                        help='Load image arrays from .npy files')
     parser.add_argument('--device', type=str, default="cuda")
     parser.add_argument('--workers', type=int, default=4)
     return parser.parse_args()
@@ -216,7 +226,8 @@ if __name__ == '__main__':
                   mapping=mapping,
                   train_path=train_dir,
                   val_dir=val_dir,
-                  workers=args.workers)
+                  workers=args.workers,
+                  load_np=args.load_np)
     except KeyboardInterrupt:
         torch.save(net.state_dict(), 'INTERRUPTED.pth')
         logging.info('Saved interrupt')

--- a/utils/numpy_loading.py
+++ b/utils/numpy_loading.py
@@ -5,7 +5,7 @@ import torch
 from torch.utils.data import Dataset
 
 
-class BasicDataset(Dataset):
+class NumpyDataset(Dataset):
     def __init__(self, images_dir: str, masks_dir: str, scale: float = 1.0, mask_suffix: str = '', mapping={}, train=False):
         if train:
             self.images = np.load(str(images_dir) + "/train_X.npy")

--- a/utils/numpy_loading.py
+++ b/utils/numpy_loading.py
@@ -1,0 +1,36 @@
+import logging
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+class BasicDataset(Dataset):
+    def __init__(self, images_dir: str, masks_dir: str, scale: float = 1.0, mask_suffix: str = '', mapping={}, train=False):
+        if train:
+            self.images = np.load(str(images_dir) + "/train_X.npy")
+            self.masks = np.load(str(masks_dir) + "/train_seg.npy")
+        else:
+            self.images = np.load(str(images_dir) + "/valid_X.npy")
+            self.masks = np.load(str(masks_dir) + "/valid_seg.npy")
+        assert 0 < scale <= 1, 'Scale must be between 0 and 1'
+        self.mapping = mapping
+
+        logging.info(f'Creating dataset with {self.images.shape[0]} examples')
+
+    def __len__(self):
+        return self.images.shape[0]
+
+
+    def __getitem__(self, idx):
+        img = self.images[idx]
+        mask = self.masks[idx]
+
+        img = img.reshape((64, 64, 3)).transpose((2, 0, 1)) / 255
+        mask = mask.reshape((64,64))
+
+        return {
+            'image': torch.as_tensor(img.copy()).float().contiguous(),
+            'mask': torch.as_tensor(mask.copy()).long().contiguous()
+        }
+


### PR DESCRIPTION
data_loading.py: load whatever format the images come in into PIL Image -> numpy array -> preprocess -> pytorch tensor

numpy_loading.py: load numpy arrays from .npy file -> pytorch tensor. GPU doesn't have to wait for CPU to read files in and create dataloader. Now the .npy files containing N x H x W x C should be in their respective folders.
